### PR TITLE
Error handling in engine API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Builds
 build
 *.out
+*.test
 
 # General
 *.tgz

--- a/api/server.go
+++ b/api/server.go
@@ -16,84 +16,16 @@ type Server struct {
 	hs *http.Server
 }
 
+// ClientHandle is a function that handles an http route and accepts a ControllerClient
+// in addition to the normal httprouter.Handle parameters.
+type ClientHandle func(http.ResponseWriter, *http.Request, httprouter.Params, pb.ControllerClient)
+
 // New creates a new api server
 func New(addr string, c pb.ControllerClient) *Server {
 	router := httprouter.New()
-	router.POST("/game/create", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			log.WithError(err).Error("Unable to read request body")
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(err.Error()))
-			return
-		}
-		req := &pb.CreateRequest{}
-
-		err = json.Unmarshal(body, req)
-		if err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("Invalid JSON: " + err.Error()))
-			return
-		}
-
-		// TODO: use a context with timeout
-		resp, err := c.Create(context.Background(), req)
-		if err != nil {
-			log.WithError(err).Error("Error creating game")
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(err.Error()))
-			return
-		}
-
-		j, err := json.Marshal(resp)
-		if err != nil {
-			log.WithError(err).WithField("resp", resp).Error("Error serializing to JSON")
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(err.Error()))
-			return
-		}
-		w.Write(j)
-	})
-
-	router.POST("/game/start/:id", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		id := ps.ByName("id")
-		req := &pb.StartRequest{
-			ID: id,
-		}
-		// TODO: use a context with timeout
-		_, err := c.Start(context.Background(), req)
-		if err != nil {
-			log.WithError(err).WithField("req", req).Error("Error while calling controller start")
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(err.Error()))
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-
-	router.GET("/game/status/:id", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		id := ps.ByName("id")
-		req := &pb.StatusRequest{
-			ID: id,
-		}
-		// TODO: use a context with timeout
-		resp, err := c.Status(context.Background(), req)
-		if err != nil {
-			log.WithError(err).WithField("req", req).Error("Error while calling controller status")
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(err.Error()))
-			return
-		}
-
-		j, err := json.Marshal(resp)
-		if err != nil {
-			log.WithError(err).WithField("resp", resp).Error("Error serializing response to JSON")
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(err.Error()))
-			return
-		}
-		w.Write(j)
-	})
+	router.POST("/game/create", clientHandle(c, createGame))
+	router.POST("/game/start/:id", clientHandle(c, startGame))
+	router.GET("/game/status/:id", clientHandle(c, getStatus))
 
 	return &Server{
 		hs: &http.Server{
@@ -101,6 +33,88 @@ func New(addr string, c pb.ControllerClient) *Server {
 			Handler: router,
 		},
 	}
+}
+
+func clientHandle(c pb.ControllerClient, innerHandle ClientHandle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		innerHandle(w, r, p, c)
+	}
+}
+
+func createGame(w http.ResponseWriter, r *http.Request, _ httprouter.Params, c pb.ControllerClient) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.WithError(err).Error("Unable to read request body")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	req := &pb.CreateRequest{}
+
+	err = json.Unmarshal(body, req)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Invalid JSON: " + err.Error()))
+		return
+	}
+
+	// TODO: use a context with timeout
+	resp, err := c.Create(context.Background(), req)
+	if err != nil {
+		log.WithError(err).Error("Error creating game")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	j, err := json.Marshal(resp)
+	if err != nil {
+		log.WithError(err).WithField("resp", resp).Error("Error serializing to JSON")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	w.Write(j)
+}
+
+func startGame(w http.ResponseWriter, r *http.Request, ps httprouter.Params, c pb.ControllerClient) {
+	id := ps.ByName("id")
+	req := &pb.StartRequest{
+		ID: id,
+	}
+	// TODO: use a context with timeout
+	_, err := c.Start(context.Background(), req)
+	if err != nil {
+		log.WithError(err).WithField("req", req).Error("Error while calling controller start")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func getStatus(w http.ResponseWriter, r *http.Request, ps httprouter.Params, c pb.ControllerClient) {
+	id := ps.ByName("id")
+	req := &pb.StatusRequest{
+		ID: id,
+	}
+	// TODO: use a context with timeout
+	resp, err := c.Status(context.Background(), req)
+	if err != nil {
+		log.WithError(err).WithField("req", req).Error("Error while calling controller status")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	j, err := json.Marshal(resp)
+	if err != nil {
+		log.WithError(err).WithField("resp", resp).Error("Error serializing response to JSON")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	w.Write(j)
 }
 
 // WaitForExit starts up the server and blocks until the server shuts down.

--- a/api/server.go
+++ b/api/server.go
@@ -16,16 +16,16 @@ type Server struct {
 	hs *http.Server
 }
 
-// ClientHandle is a function that handles an http route and accepts a ControllerClient
+// clientHandle is a function that handles an http route and accepts a ControllerClient
 // in addition to the normal httprouter.Handle parameters.
-type ClientHandle func(http.ResponseWriter, *http.Request, httprouter.Params, pb.ControllerClient)
+type clientHandle func(http.ResponseWriter, *http.Request, httprouter.Params, pb.ControllerClient)
 
 // New creates a new api server
 func New(addr string, c pb.ControllerClient) *Server {
 	router := httprouter.New()
-	router.POST("/game/create", clientHandle(c, createGame))
-	router.POST("/game/start/:id", clientHandle(c, startGame))
-	router.GET("/game/status/:id", clientHandle(c, getStatus))
+	router.POST("/game/create", clientHandler(c, createGame))
+	router.POST("/game/start/:id", clientHandler(c, startGame))
+	router.GET("/game/status/:id", clientHandler(c, getStatus))
 
 	return &Server{
 		hs: &http.Server{
@@ -35,7 +35,7 @@ func New(addr string, c pb.ControllerClient) *Server {
 	}
 }
 
-func clientHandle(c pb.ControllerClient, innerHandle ClientHandle) httprouter.Handle {
+func clientHandler(c pb.ControllerClient, innerHandle clientHandle) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		innerHandle(w, r, p, c)
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -23,9 +23,9 @@ type clientHandle func(http.ResponseWriter, *http.Request, httprouter.Params, pb
 // New creates a new api server
 func New(addr string, c pb.ControllerClient) *Server {
 	router := httprouter.New()
-	router.POST("/game/create", clientHandler(c, createGame))
-	router.POST("/game/start/:id", clientHandler(c, startGame))
-	router.GET("/game/status/:id", clientHandler(c, getStatus))
+	router.POST("/game/create", newClientHandle(c, createGame))
+	router.POST("/game/start/:id", newClientHandle(c, startGame))
+	router.GET("/game/status/:id", newClientHandle(c, getStatus))
 
 	return &Server{
 		hs: &http.Server{
@@ -35,7 +35,7 @@ func New(addr string, c pb.ControllerClient) *Server {
 	}
 }
 
-func clientHandler(c pb.ControllerClient, innerHandle clientHandle) httprouter.Handle {
+func newClientHandle(c pb.ControllerClient, innerHandle clientHandle) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		innerHandle(w, r, p, c)
 	}

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -110,3 +110,13 @@ func TestStatus(t *testing.T) {
 	s.hs.Handler.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 }
+
+func TestStatusHandlesErrors(t *testing.T) {
+	s, _ := createAPIServerWithError()
+
+	req, _ := http.NewRequest("GET", "/game/status/abc_123", nil)
+	rr := httptest.NewRecorder()
+
+	s.hs.Handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+}


### PR DESCRIPTION
Fixes battlesnakeio/roadmap#22

1. /game/create handles invalid request JSON and returns 400 response including unit test.
2. /game/create handles errors from ControllerClient.Create and returns 500 response including unit test.
3. /game/create handles json serialization errors, but there is actually no value you can pass that will create an error (according to docs) based on the type. This is really a "just in case" error handler.
4. /game/status/:id handles json serialization errors like in 3.
5. .gitignore ignores *.test which is generated by `go test -c ...` or when you run tests from vscode.