### PR TITLE
some basic load testing in the cli

### DIFF
--- a/cmd/engine-cli/commands/create.go
+++ b/cmd/engine-cli/commands/create.go
@@ -27,30 +27,40 @@ var createCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(*cobra.Command, []string) {
-		client := &http.Client{
-			Timeout: 5 * time.Second,
-		}
-
-		data, err := json.Marshal(cr)
-		if err != nil {
-			fmt.Println("unable to marshal request", err)
-			return
-		}
-		buf := bytes.NewBuffer(data)
-		resp, err := client.Post(fmt.Sprintf("%s/games", apiAddr), "application/json", buf)
-		if err != nil {
-			fmt.Println("error while posting to create endpoint", err)
-			return
-		}
-
-		data, err = ioutil.ReadAll(resp.Body)
-		if err != nil {
-			fmt.Println("unable to read response body", err)
-			return
-		}
-
-		fmt.Println(string(data))
+		cr := createGame()
+		fmt.Println(cr)
 	},
+}
+
+func createGame() *pb.CreateResponse {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	data, err := json.Marshal(cr)
+	if err != nil {
+		fmt.Println("unable to marshal request", err)
+		return nil
+	}
+	buf := bytes.NewBuffer(data)
+	resp, err := client.Post(fmt.Sprintf("%s/games", apiAddr), "application/json", buf)
+	if err != nil {
+		fmt.Println("error while posting to create endpoint", err)
+		return nil
+	}
+
+	data, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("unable to read response body", err)
+		return nil
+	}
+
+	cr := &pb.CreateResponse{}
+	err = json.Unmarshal(data, &cr)
+	if err != nil {
+		fmt.Println("Unable to unmarshal create response")
+	}
+	return cr
 }
 
 var (

--- a/cmd/engine-cli/commands/loadtest.go
+++ b/cmd/engine-cli/commands/loadtest.go
@@ -1,0 +1,99 @@
+package commands
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"time"
+
+	"github.com/battlesnakeio/engine/rules"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	games int
+)
+
+func init() {
+	loadTestCmd.Flags().StringVarP(&configFile, "config", "c", "snake-config.json", "specify the location of the snake config file")
+	loadTestCmd.Flags().IntVarP(&games, "num-games", "n", 10, "number of games to create and run for the load test")
+}
+
+type statusUpdate struct {
+	id     string
+	status string
+}
+
+var loadTestCmd = &cobra.Command{
+	Use:   "load-test",
+	Short: "run a load test against the engine, using the provided snake config",
+	Args: func(c *cobra.Command, args []string) error {
+		data, err := ioutil.ReadFile(configFile)
+		if err != nil {
+			return err
+		}
+		err = json.Unmarshal(data, cr)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	Run: func(*cobra.Command, []string) {
+		start := time.Now()
+		ids := []string{}
+		log.Info("Creating games")
+		for i := 0; i < games; i++ {
+			cr := createGame()
+			ids = append(ids, cr.ID)
+			runGame(cr.ID)
+		}
+
+		statuses := map[string]string{}
+		updates := make(chan statusUpdate)
+		for _, id := range ids {
+			statuses[id] = ""
+			go checkStatus(id, updates)
+		}
+
+		for s := range updates {
+			log.WithFields(log.Fields{
+				"id":     s.id,
+				"status": s.status,
+			}).Info("Game Status")
+			statuses[s.id] = s.status
+
+			done := true
+			for _, s := range statuses {
+				if s == rules.GameStatusComplete || s == rules.GameStatusError {
+					continue
+				}
+				done = false
+			}
+
+			if done {
+				log.WithFields(log.Fields{
+					"elapsed": time.Since(start),
+					"games":   games,
+				}).Info("All games complete")
+				return
+			}
+		}
+	},
+}
+
+var updateFrequency = 300 * time.Millisecond
+
+func checkStatus(id string, updates chan<- statusUpdate) {
+	t := time.NewTicker(updateFrequency)
+	for {
+		select {
+		case <-t.C:
+			sr := getStatus(id)
+			updates <- statusUpdate{id: id, status: sr.Game.Status}
+			if sr.Game.Status == rules.GameStatusComplete || sr.Game.Status == rules.GameStatusError {
+				t.Stop()
+				return
+			}
+		}
+	}
+}

--- a/cmd/engine-cli/commands/root.go
+++ b/cmd/engine-cli/commands/root.go
@@ -25,6 +25,7 @@ func Execute() {
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(replayCmd)
+	rootCmd.AddCommand(loadTestCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/cmd/engine-cli/commands/run.go
+++ b/cmd/engine-cli/commands/run.go
@@ -25,22 +25,26 @@ var runCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(*cobra.Command, []string) {
-		client := &http.Client{
-			Timeout: 5 * time.Second,
-		}
-
-		resp, err := client.Post(fmt.Sprintf("%s/games/%s/start", apiAddr, gameID), "application/json", &bytes.Buffer{})
-		if err != nil {
-			fmt.Println("error while posting to start endpoint", err)
-			return
-		}
-
-		data, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			fmt.Println("unable to read response body", err)
-			return
-		}
-
-		fmt.Println(string(data))
+		runGame(gameID)
 	},
+}
+
+func runGame(id string) string {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Post(fmt.Sprintf("%s/games/%s/start", apiAddr, id), "application/json", &bytes.Buffer{})
+	if err != nil {
+		fmt.Println("error while posting to start endpoint", err)
+		return ""
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("unable to read response body", err)
+		return ""
+	}
+
+	return string(data)
 }


### PR DESCRIPTION
added a `load-test` command to the cli, which runs games against a running server. By default it will start, run, and time 10 games. On my macbook against a local snake with 10 workers running in the engine, the server took about 15s to handle 100 games.

This also fixes battlesnakeio/roadmap#74