### PR TITLE
Ping controller less frequently

### DIFF
--- a/cmd/engine/commands/worker.go
+++ b/cmd/engine/commands/worker.go
@@ -13,6 +13,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const pingRetryDelay = 1 * time.Second
+
 var (
 	workerThreads      = 10
 	workerPollInterval = 1 * time.Second
@@ -79,6 +81,7 @@ var workerCmd = &cobra.Command{
 					break
 				} else {
 					log.WithError(err).Warn("controller connection unhealthy")
+					time.Sleep(pingRetryDelay)
 				}
 			}
 		}()


### PR DESCRIPTION
Mostly fixes battlesnakeio/roadmap#82

Not sure how best to address this but this PR at least illustrates the problem.

Theoretically it's not really an issue that the workers could start before the controller since it just retries over and over until the controller is online, it just might be overkill to do it with no delay. This would solve two problems:

1. If you run `engine all` then your log will never instantly fill with warnings, *but it might still get one set of warnings on startup which is annoying*.
2. If you run `engine worker` when there is no controller running anywhere then there is a spammy stream of warnings spewing to the log and it uses a ton of CPU until the controller comes online.

The next step better than this would to somehow avoid printing any warnings at all when the controller is still starting either by synchronizing the two workers or by being more sophisticated about when the warnings are logged.