### PR TITLE
logging middleware and safeguard for grabbing initial frame in replay

### DIFF
--- a/cmd/engine/commands/render.go
+++ b/cmd/engine/commands/render.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 
@@ -16,6 +17,9 @@ const (
 )
 
 func render(game *pb.Game, frame *pb.GameFrame) error {
+	if frame == nil {
+		return errors.New("received nil frame")
+	}
 	err := termbox.Clear(defaultColor, defaultColor)
 	if err != nil {
 		return err


### PR DESCRIPTION
Sometimes the replay was too fast, and tried to start playing before the initial frame came over the socket, this gives the replay 100ms for the first frame to arrive