### PR TITLE
Food spawning refactor

### DIFF
--- a/rules/create.go
+++ b/rules/create.go
@@ -21,7 +21,6 @@ const (
 
 // CreateInitialGame creates a new game based on the create request passed in
 func CreateInitialGame(req *pb.CreateRequest) (*pb.Game, []*pb.GameFrame, error) {
-
 	snakes, err := getSnakes(req)
 	if err != nil {
 		return nil, nil, err
@@ -61,9 +60,9 @@ func getSnakes(req *pb.CreateRequest) ([]*pb.Snake, error) {
 	snakes := []*pb.Snake{}
 
 	for _, opts := range req.Snakes {
-		startPoint, err := getUnoccupiedPoint(req.Width, req.Height, []*pb.Point{}, snakes)
-		if err != nil {
-			return nil, err
+		startPoint := getUnoccupiedPoint(req.Width, req.Height, []*pb.Point{}, snakes)
+		if startPoint == nil {
+			return nil, errors.New("no unoccupied spots left for new snake")
 		}
 		snake := &pb.Snake{
 			ID:     opts.ID,
@@ -96,11 +95,10 @@ func generateFood(req *pb.CreateRequest, snakes []*pb.Snake) ([]*pb.Point, error
 	food := []*pb.Point{}
 
 	for i := int64(0); i < req.Food; i++ {
-		p, err := getUnoccupiedPoint(req.Width, req.Height, food, snakes)
-		if err != nil {
-			return nil, err
+		p := getUnoccupiedPoint(req.Width, req.Height, food, snakes)
+		if p != nil {
+			food = append(food, p)
 		}
-		food = append(food, p)
 	}
 
 	return food, nil

--- a/rules/create_test.go
+++ b/rules/create_test.go
@@ -37,3 +37,19 @@ func TestCreateInitialGame_GeneratedSnakeID(t *testing.T) {
 	require.Len(t, frames, 1)
 	require.NotEmpty(t, frames[0].Snakes[0].ID)
 }
+
+func TestCreateInitialGame_MoreSnakesThanSpace(t *testing.T) {
+	_, _, err := CreateInitialGame(&pb.CreateRequest{
+		Width:  2,
+		Height: 2,
+		Snakes: []*pb.SnakeOptions{
+			{ID: "snake_123"},
+			{ID: "snake_124"},
+			{ID: "snake_125"},
+			{ID: "snake_126"},
+			{ID: "snake_127"},
+		},
+	})
+
+	require.Error(t, err)
+}

--- a/rules/tick.go
+++ b/rules/tick.go
@@ -100,22 +100,20 @@ func updateFood(width, height int64, gameFrame *pb.GameFrame, foodToRemove []*pb
 	return food, nil
 }
 
-func getUnoccupiedPoint(width int64, height int64, food []*pb.Point, snakes []*pb.Snake) (*pb.Point, error) {
-	openPoints, _ := getUnoccupiedPoints(width, height, food, snakes)
+func getUnoccupiedPoint(width, height int64, food []*pb.Point, snakes []*pb.Snake) (*pb.Point, error) {
+	openPoints := getUnoccupiedPoints(width, height, food, snakes)
 
 	randIndex := rand.Intn(len(openPoints))
 
 	return openPoints[randIndex], nil
 }
 
-func getUnoccupiedPoints(width int64, height int64, food []*pb.Point, snakes []*pb.Snake) ([]*pb.Point, error) {
-	occupiedPoints, _ := getUniqOccupiedPoints(food, snakes)
+func getUnoccupiedPoints(width, height int64, food []*pb.Point, snakes []*pb.Snake) ([]*pb.Point) {
+	occupiedPoints := getUniqOccupiedPoints(food, snakes)
 
 	numCandidatePoints := int(width*height) - len(occupiedPoints)
 
-	candidatePoints := make([]*pb.Point, numCandidatePoints)
-
-	index := 0
+	candidatePoints := make([]*pb.Point, 0, numCandidatePoints)
 
 	for x := int64(0); x < width; x++ {
 		for y := int64(0); y < height; y++ {
@@ -130,47 +128,37 @@ func getUnoccupiedPoints(width int64, height int64, food []*pb.Point, snakes []*
 			}
 
 			if !match {
-				candidatePoints[index] = p
-				index++
+				candidatePoints = append(candidatePoints, p)
 			}
 		}
 	}
 
-	return candidatePoints, nil
+	return candidatePoints
 }
 
-func getUniqOccupiedPoints(food []*pb.Point, snakes []*pb.Snake) ([]*pb.Point, error) {
+func getUniqOccupiedPoints(food []*pb.Point, snakes []*pb.Snake) ([]*pb.Point) {
 	occupiedPoints := []*pb.Point{}
 
 	for _, f := range food {
-		candidate := true
 		for _, o := range occupiedPoints {
 			if o.Equal(f) {
-				candidate = false
+				occupiedPoints = append(occupiedPoints, f)
+				break
 			}
-		}
-
-		if candidate {
-			occupiedPoints = append(occupiedPoints, f)
 		}
 	}
 
 	for _, s := range snakes {
 		for _, b := range s.Body {
-			candidate := true
 			for _, o := range occupiedPoints {
 				if o.Equal(b) {
-					candidate = false
+					occupiedPoints = append(occupiedPoints, b)
 				}
-			}
-
-			if candidate {
-				occupiedPoints = append(occupiedPoints, b)
 			}
 		}
 	}
 
-	return occupiedPoints, nil
+	return occupiedPoints
 }
 
 func updateSnakes(game *pb.Game, frame *pb.GameFrame, moves []*SnakeUpdate) {

--- a/rules/tick.go
+++ b/rules/tick.go
@@ -111,15 +111,15 @@ func getUnoccupiedPoint(width int64, height int64, food []*pb.Point, snakes []*p
 func getUnoccupiedPoints(width int64, height int64, food []*pb.Point, snakes []*pb.Snake) ([]*pb.Point, error) {
 	occupiedPoints, _ := getUniqOccupiedPoints(food, snakes)
 
-	numCandidatePoints := int(width*height)-len(occupiedPoints)
+	numCandidatePoints := int(width*height) - len(occupiedPoints)
 
 	candidatePoints := make([]*pb.Point, numCandidatePoints)
 
 	index := 0
 
-  for  x := int64(0); x < width; x++ {
-    for  y := int64(0); y < height; y++ {
- 			p := &pb.Point{X: x, Y: y}
+	for x := int64(0); x < width; x++ {
+		for y := int64(0); y < height; y++ {
+			p := &pb.Point{X: x, Y: y}
 			match := false
 
 			for _, o := range occupiedPoints {
@@ -133,12 +133,11 @@ func getUnoccupiedPoints(width int64, height int64, food []*pb.Point, snakes []*
 				candidatePoints[index] = p
 				index++
 			}
-    }
-  }
+		}
+	}
 
-  return candidatePoints, nil
+	return candidatePoints, nil
 }
-
 
 func getUniqOccupiedPoints(food []*pb.Point, snakes []*pb.Snake) ([]*pb.Point, error) {
 	occupiedPoints := []*pb.Point{}
@@ -146,12 +145,12 @@ func getUniqOccupiedPoints(food []*pb.Point, snakes []*pb.Snake) ([]*pb.Point, e
 	for _, f := range food {
 		candidate := true
 		for _, o := range occupiedPoints {
-			if (o.Equal(f)) {
+			if o.Equal(f) {
 				candidate = false
 			}
 		}
 
-		if (candidate) {
+		if candidate {
 			occupiedPoints = append(occupiedPoints, f)
 		}
 	}
@@ -160,12 +159,12 @@ func getUniqOccupiedPoints(food []*pb.Point, snakes []*pb.Snake) ([]*pb.Point, e
 		for _, b := range s.Body {
 			candidate := true
 			for _, o := range occupiedPoints {
-				if (o.Equal(b)) {
+				if o.Equal(b) {
 					candidate = false
 				}
 			}
 
-			if (candidate) {
+			if candidate {
 				occupiedPoints = append(occupiedPoints, b)
 			}
 		}

--- a/rules/tick.go
+++ b/rules/tick.go
@@ -90,25 +90,28 @@ func updateFood(width, height int64, gameFrame *pb.GameFrame, foodToRemove []*pb
 	}
 
 	for range foodToRemove {
-		p, err := getUnoccupiedPoint(width, height, gameFrame.Food, gameFrame.AliveSnakes())
-		if err != nil {
-			return nil, err
+		p := getUnoccupiedPoint(width, height, gameFrame.Food, gameFrame.AliveSnakes())
+		if p != nil {
+			food = append(food, p)
 		}
-		food = append(food, p)
 	}
 
 	return food, nil
 }
 
-func getUnoccupiedPoint(width, height int64, food []*pb.Point, snakes []*pb.Snake) (*pb.Point, error) {
+func getUnoccupiedPoint(width, height int64, food []*pb.Point, snakes []*pb.Snake) *pb.Point {
 	openPoints := getUnoccupiedPoints(width, height, food, snakes)
+
+	if len(openPoints) == 0 {
+		return nil
+	}
 
 	randIndex := rand.Intn(len(openPoints))
 
-	return openPoints[randIndex], nil
+	return openPoints[randIndex]
 }
 
-func getUnoccupiedPoints(width, height int64, food []*pb.Point, snakes []*pb.Snake) ([]*pb.Point) {
+func getUnoccupiedPoints(width, height int64, food []*pb.Point, snakes []*pb.Snake) []*pb.Point {
 	occupiedPoints := getUniqOccupiedPoints(food, snakes)
 
 	numCandidatePoints := int(width*height) - len(occupiedPoints)
@@ -136,24 +139,32 @@ func getUnoccupiedPoints(width, height int64, food []*pb.Point, snakes []*pb.Sna
 	return candidatePoints
 }
 
-func getUniqOccupiedPoints(food []*pb.Point, snakes []*pb.Snake) ([]*pb.Point) {
+func getUniqOccupiedPoints(food []*pb.Point, snakes []*pb.Snake) []*pb.Point {
 	occupiedPoints := []*pb.Point{}
-
 	for _, f := range food {
+		candidate := true
 		for _, o := range occupiedPoints {
 			if o.Equal(f) {
-				occupiedPoints = append(occupiedPoints, f)
+				candidate = false
 				break
 			}
+		}
+		if candidate {
+			occupiedPoints = append(occupiedPoints, f)
 		}
 	}
 
 	for _, s := range snakes {
 		for _, b := range s.Body {
+			candidate := true
 			for _, o := range occupiedPoints {
 				if o.Equal(b) {
-					occupiedPoints = append(occupiedPoints, b)
+					candidate = false
+					break
 				}
+			}
+			if candidate {
+				occupiedPoints = append(occupiedPoints, b)
 			}
 		}
 	}

--- a/rules/tick_test.go
+++ b/rules/tick_test.go
@@ -35,6 +35,78 @@ func TestUpdateFood(t *testing.T) {
 	require.False(t, updated[1].Equal(&pb.Point{X: 1, Y: 1}))
 }
 
+func TestUpdateFoodWithFullBoard(t *testing.T) {
+	updated, err := updateFood(2, 2, &pb.GameFrame{
+		Food: []*pb.Point{
+			{X: 0, Y: 0},
+		},
+		Snakes: []*pb.Snake{
+			{
+				Body: []*pb.Point{
+					{X: 0, Y: 0},
+					{X: 0, Y: 1},
+					{X: 1, Y: 1},
+					{X: 1, Y: 0},
+				},
+			},
+		},
+	}, []*pb.Point{
+		{X: 0, Y: 0},
+	})
+	require.NoError(t, err)
+	require.Len(t, updated, 0)
+}
+
+func TestGetUnoccupiedPointWithFullBoard(t *testing.T) {
+	unoccupiedPoint := getUnoccupiedPoint(2, 2,
+		[]*pb.Point{{X: 0, Y: 0}},
+		[]*pb.Snake{
+			{
+				Body: []*pb.Point{
+					{X: 0, Y: 1},
+					{X: 1, Y: 1},
+					{X: 1, Y: 0},
+				},
+			},
+		})
+	require.True(t, unoccupiedPoint.Equal(nil))
+}
+
+func TestGetUnoccupiedPointsWithEmptySpots(t *testing.T) {
+	unoccupiedPoints := getUnoccupiedPoints(2, 2,
+		[]*pb.Point{{X: 0, Y: 0}},
+		[]*pb.Snake{
+			{
+				Body: []*pb.Point{
+					{X: 0, Y: 1},
+				},
+			},
+		})
+
+	require.Len(t, unoccupiedPoints, 2)
+	require.True(t, unoccupiedPoints[0].Equal(&pb.Point{X: 1, Y: 0}))
+	require.True(t, unoccupiedPoints[1].Equal(&pb.Point{X: 1, Y: 1}))
+}
+
+func TestGetUniqOccupiedPoints(t *testing.T) {
+	unoccupiedPoints := getUniqOccupiedPoints(
+		[]*pb.Point{
+			{X: 0, Y: 0},
+		},
+		[]*pb.Snake{
+			{
+				Body: []*pb.Point{
+					{X: 0, Y: 1},
+					{X: 1, Y: 1},
+					{X: 1, Y: 1},
+					{X: 1, Y: 0},
+				},
+			},
+		})
+
+	require.Len(t, unoccupiedPoints, 4)
+}
+
 func TestGameTickUpdatesTurnCounter(t *testing.T) {
 	gt, err := GameTick(commonGame, &pb.GameFrame{Turn: 5})
 	require.NoError(t, err)

--- a/rules/tick_test.go
+++ b/rules/tick_test.go
@@ -18,6 +18,8 @@ func TestUpdateFood(t *testing.T) {
 			{
 				Body: []*pb.Point{
 					{X: 1, Y: 2},
+					{X: 2, Y: 2},
+					{X: 3, Y: 2},
 				},
 			},
 		},
@@ -26,7 +28,11 @@ func TestUpdateFood(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, updated, 2)
-	require.False(t, updated[1].Equal(&pb.Point{X: 1, Y: 2}))
+	require.True(t, updated[0].Equal(&pb.Point{X: 1,  Y: 1}))
+	require.False(t, updated[1].Equal(&pb.Point{X: 1,  Y: 2}))
+	require.False(t, updated[1].Equal(&pb.Point{X: 2,  Y: 2}))
+	require.False(t, updated[1].Equal(&pb.Point{X: 3,  Y: 2}))
+	require.False(t, updated[1].Equal(&pb.Point{X: 1,  Y: 1}))
 }
 
 func TestGameTickUpdatesTurnCounter(t *testing.T) {

--- a/rules/tick_test.go
+++ b/rules/tick_test.go
@@ -28,11 +28,11 @@ func TestUpdateFood(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, updated, 2)
-	require.True(t, updated[0].Equal(&pb.Point{X: 1,  Y: 1}))
-	require.False(t, updated[1].Equal(&pb.Point{X: 1,  Y: 2}))
-	require.False(t, updated[1].Equal(&pb.Point{X: 2,  Y: 2}))
-	require.False(t, updated[1].Equal(&pb.Point{X: 3,  Y: 2}))
-	require.False(t, updated[1].Equal(&pb.Point{X: 1,  Y: 1}))
+	require.True(t, updated[0].Equal(&pb.Point{X: 1, Y: 1}))
+	require.False(t, updated[1].Equal(&pb.Point{X: 1, Y: 2}))
+	require.False(t, updated[1].Equal(&pb.Point{X: 2, Y: 2}))
+	require.False(t, updated[1].Equal(&pb.Point{X: 3, Y: 2}))
+	require.False(t, updated[1].Equal(&pb.Point{X: 1, Y: 1}))
 }
 
 func TestGameTickUpdatesTurnCounter(t *testing.T) {


### PR DESCRIPTION
# Summary

A refactor of how an unoccupied point is found. Instead of trying 20 times to find an unoccupied point, which becomes more of a problem the longer snakes are alive, find all the blank spots on the board and randomly select one. 

1. Create a slice of occupied points.
2. Create a a slice of unoccupied points based on #1 
3. Randomly select an item from the slice.

From issue [#106](https://github.com/battlesnakeio/roadmap/issues/106)

## Handling of no unoccupied points

Return nil when no unoccupied points are available. 

- In the case of adding food, if no more occupied points are available then that's fine -- just continue. 
- In the case of game creation, if there are more snakes then there is space on the board, return an error.

Added tests to to _tick_test.go_ and _create_test.go_.

## Collecting occupied points

There's a codeclimate refactor [here](https://codeclimate.com/github/battlesnakeio/engine/pull/40) for collecting unoccupied points. It has a high complexity because we have to check for duplicate points (which does happen when snakes spawn -- all their body parts are on the same point). A potential refactor would be to use a map system to verify if a spot has already been accounted for.  But do we care?? :D

Refer to _getUniqOccupiedPoints_ in tick.go.
