### PR TITLE
[Issue #110] Snake doesn't die when it crashes into itself

### DIFF
--- a/rules/death.go
+++ b/rules/death.go
@@ -39,12 +39,8 @@ func checkForDeath(width, height int64, frame *pb.GameFrame) []deathUpdate {
 		}
 
 		for _, other := range frame.AliveSnakes() {
-			if other.ID == s.ID {
-				continue
-			}
-
-			for i, b := range other.Body {
-				if i == 0 && s.Head().Equal(b) {
+			if other.ID != s.ID {
+				if s.Head().Equal(other.Head()) {
 					if len(s.Body) <= len(other.Body) {
 						updates = append(updates, deathUpdate{
 							Snake: s,
@@ -53,16 +49,28 @@ func checkForDeath(width, height int64, frame *pb.GameFrame) []deathUpdate {
 								Cause: DeathCauseHeadToHeadCollision,
 							},
 						})
-						break
 					}
+				}
+			}
+
+			for i, b := range other.Body {
+				if i == 0 {
+					continue
 				}
 
 				if s.Head().Equal(b) {
+					var cause string
+					if s.ID == other.ID {
+						cause = DeathCauseSnakeSelfCollision
+					} else {
+						cause = DeathCauseSnakeCollision
+					}
+
 					updates = append(updates, deathUpdate{
 						Snake: s,
 						Death: &pb.Death{
 							Turn:  frame.Turn,
-							Cause: DeathCauseSnakeCollision,
+							Cause: cause,
 						},
 					})
 					break

--- a/rules/death.go
+++ b/rules/death.go
@@ -13,7 +13,7 @@ type deathUpdate struct {
 func checkForDeath(width, height int64, frame *pb.GameFrame) []deathUpdate {
 	updates := []deathUpdate{}
 	for _, s := range frame.AliveSnakes() {
-		if s.Health == 0 {
+		if deathByHealth(s.Health) {
 			updates = append(updates, deathUpdate{
 				Snake: s,
 				Death: &pb.Death{
@@ -27,7 +27,7 @@ func checkForDeath(width, height int64, frame *pb.GameFrame) []deathUpdate {
 		if head == nil {
 			continue
 		}
-		if head.X < 0 || head.X >= width || head.Y < 0 || head.Y >= height {
+		if deathByOutOfBounds(head, width, height) {
 			updates = append(updates, deathUpdate{
 				Snake: s,
 				Death: &pb.Death{
@@ -39,18 +39,14 @@ func checkForDeath(width, height int64, frame *pb.GameFrame) []deathUpdate {
 		}
 
 		for _, other := range frame.AliveSnakes() {
-			if other.ID != s.ID {
-				if s.Head().Equal(other.Head()) {
-					if len(s.Body) <= len(other.Body) {
-						updates = append(updates, deathUpdate{
-							Snake: s,
-							Death: &pb.Death{
-								Turn:  frame.Turn,
-								Cause: DeathCauseHeadToHeadCollision,
-							},
-						})
-					}
-				}
+			if deathByHeadCollision(s, other) {
+				updates = append(updates, deathUpdate{
+					Snake: s,
+					Death: &pb.Death{
+						Turn:  frame.Turn,
+						Cause: DeathCauseHeadToHeadCollision,
+					},
+				})
 			}
 
 			for i, b := range other.Body {
@@ -58,7 +54,7 @@ func checkForDeath(width, height int64, frame *pb.GameFrame) []deathUpdate {
 					continue
 				}
 
-				if s.Head().Equal(b) {
+				if deathByBodyCollision(s.Head(), b) {
 					var cause string
 					if s.ID == other.ID {
 						cause = DeathCauseSnakeSelfCollision
@@ -79,4 +75,20 @@ func checkForDeath(width, height int64, frame *pb.GameFrame) []deathUpdate {
 		}
 	}
 	return updates
+}
+
+func deathByHealth(health int64) bool {
+	return health <= 0
+}
+
+func deathByBodyCollision(head, body *pb.Point) bool {
+	return head.Equal(body)
+}
+
+func deathByOutOfBounds(head *pb.Point, width, height int64) bool {
+	return (head.X < 0) || (head.X >= width) || (head.Y < 0) || (head.Y >= height)
+}
+
+func deathByHeadCollision(snake, other *pb.Snake) bool {
+	return (other.ID != snake.ID) && (snake.Head().Equal(other.Head())) && (len(snake.Body) <= len(other.Body))
 }

--- a/rules/death_cause.go
+++ b/rules/death_cause.go
@@ -3,7 +3,7 @@ package rules
 const (
 	// DeathCauseSnakeCollision is the death reason when 2 snakes collide with each other
 	DeathCauseSnakeCollision = "snake-collision"
-	// DeathCauseSnakeCollision is the death reason when 2 snakes collide with each other
+	// DeathCauseSnakeSelfCollision is the death reason when a snake collides with itself
 	DeathCauseSnakeSelfCollision = "snake-self-collision"
 	// DeathCauseStarvation is the death reason when a snakes health reaches zero
 	DeathCauseStarvation = "starvation"

--- a/rules/death_cause.go
+++ b/rules/death_cause.go
@@ -3,6 +3,8 @@ package rules
 const (
 	// DeathCauseSnakeCollision is the death reason when 2 snakes collide with each other
 	DeathCauseSnakeCollision = "snake-collision"
+	// DeathCauseSnakeCollision is the death reason when 2 snakes collide with each other
+	DeathCauseSnakeSelfCollision = "snake-self-collision"
 	// DeathCauseStarvation is the death reason when a snakes health reaches zero
 	DeathCauseStarvation = "starvation"
 	// DeathCauseHeadToHeadCollision is when a snake dies from a head on head collision

--- a/rules/death_test.go
+++ b/rules/death_test.go
@@ -99,3 +99,25 @@ func TestDeathCauseHeadToHeadCollision(t *testing.T) {
 	require.Equal(t, DeathCauseHeadToHeadCollision, updates[1].Death.Cause)
 	require.Equal(t, int64(3), updates[1].Death.Turn)
 }
+
+func TestDeathCauseSnakeSelfCollision(t *testing.T) {
+	updates := checkForDeath(20, 20, &pb.GameFrame{
+		Turn: 3,
+		Snakes: []*pb.Snake{
+			&pb.Snake{
+				ID:     "1",
+				Health: 45,
+				Body: []*pb.Point{
+					{X: 4, Y: 4},
+					{X: 3, Y: 4},
+					{X: 3, Y: 3},
+					{X: 4, Y: 3},
+					{X: 4, Y: 4},
+				},
+			},
+		},
+	})
+	require.Len(t, updates, 1)
+	require.Equal(t, DeathCauseSnakeSelfCollision, updates[0].Death.Cause)
+	require.Equal(t, int64(3), updates[0].Death.Turn)
+}


### PR DESCRIPTION
# Summary

Currently, one's snake doesn't die when it crashes into itself.

# Fix

1. Only check head collision with _other_ snakes
2. Check for body collisions for _self and other_ snakes 
3. New DeathCauseSnakeSelfCollision

# Tests

Added a test for a snake crashing into itself. 

