### PR TITLE
Only return alive snakes in the response to clients

### DIFF
--- a/rules/api_models.go
+++ b/rules/api_models.go
@@ -64,7 +64,7 @@ func buildSnakeRequest(game *pb.Game, frame *pb.GameFrame, snakeID string) Snake
 			Height: game.Height,
 			Width:  game.Width,
 			Food:   convertPoints(frame.Food),
-			Snakes: convertSnakes(frame.Snakes),
+			Snakes: convertSnakes(frame.AliveSnakes()),
 		},
 		You: convertSnake(you),
 	}

--- a/rules/api_models_test.go
+++ b/rules/api_models_test.go
@@ -43,15 +43,15 @@ func TestBuildSnakeRequestWithOnlyAliveSnakes(t *testing.T) {
 					{X: 2, Y: 2},
 					{X: 1, Y: 2},
 				},
-        Death: &pb.Death {
-          Cause: DeathCauseStarvation,
-          Turn: 3,
-        },
+				Death: &pb.Death{
+					Cause: DeathCauseStarvation,
+					Turn:  3,
+				},
 			},
 		},
 	}, "snake_123")
-  require.Len(t, req.Board.Snakes, 1)
-  require.Equal(t,"snake_123", req.Board.Snakes[0].ID)
+	require.Len(t, req.Board.Snakes, 1)
+	require.Equal(t, "snake_123", req.Board.Snakes[0].ID)
 	require.Equal(t, []Coords{{X: 1, Y: 1}}, req.Board.Snakes[0].Body)
 	require.Equal(t, []Coords{{X: 1, Y: 1}}, req.You.Body)
 }

--- a/rules/api_models_test.go
+++ b/rules/api_models_test.go
@@ -24,3 +24,34 @@ func TestBuildSnakeRequest(t *testing.T) {
 	require.Equal(t, []Coords{{X: 1, Y: 1}}, req.Board.Snakes[0].Body)
 	require.Equal(t, []Coords{{X: 1, Y: 1}}, req.You.Body)
 }
+
+func TestBuildSnakeRequestWithOnlyAliveSnakes(t *testing.T) {
+	req := buildSnakeRequest(&pb.Game{
+		ID: "game_123",
+	}, &pb.GameFrame{
+		Snakes: []*pb.Snake{
+			{
+				ID: "snake_123",
+				Body: []*pb.Point{
+					{X: 1, Y: 1},
+				},
+			},
+			{
+				ID: "deth_snek",
+				Body: []*pb.Point{
+					{X: 2, Y: 1},
+					{X: 2, Y: 2},
+					{X: 1, Y: 2},
+				},
+        Death: &pb.Death {
+          Cause: DeathCauseStarvation,
+          Turn: 3,
+        },
+			},
+		},
+	}, "snake_123")
+  require.Len(t, req.Board.Snakes, 1)
+  require.Equal(t,"snake_123", req.Board.Snakes[0].ID)
+	require.Equal(t, []Coords{{X: 1, Y: 1}}, req.Board.Snakes[0].Body)
+	require.Equal(t, []Coords{{X: 1, Y: 1}}, req.You.Body)
+}


### PR DESCRIPTION
# Summary

[Issue #135](https://github.com/battlesnakeio/roadmap/issues/135)

Pushed a second commit that just ran gofmt on the files. Would be worth squashing the commits when merging just to keep it clean. 