### PR TITLE
Allow a single retry on timeout for snakes.

### DIFF
--- a/rules/api_client.go
+++ b/rules/api_client.go
@@ -84,6 +84,18 @@ func postToSnakeServer(req snakePostRequest, resp chan<- snakeResponse) {
 	netClient := createClient(req.options.timeout)
 	postURL := getURL(req.options.snake.URL, req.options.url)
 	postResponse, err := netClient.Post(postURL, "application/json", buf)
+
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"url": postURL,
+			"id":  req.options.snake.ID,
+		}).Error("error POSTing to snake, retrying once.")
+
+		// Perform 1 retry
+		postResponse, err = netClient.Post(postURL, "application/json", buf)
+	}
+
+	// Retry failed
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"url": postURL,


### PR DESCRIPTION
@dlsteuer I'm not sure if this is the best approach, but it might be a bandaid fix for the random timeouts I'm seeing for various snakes.

In order to prevent abuse, it might be good to limit the number of retries per game per snake (give them ~3 or something).

This will reduce game variance caused by network lag, or unexpected timeouts.

Issue: Sometimes a single timeout on a move request will vastly change the outcome of a game.

(I've picked some examples where my snake goes in the wrong direction from what is sent. I've observed this happening with other snakes as well, so it's not isolated to me).

For context, my server is set up to respond within 200ms, which is well below the current server timeout.

Examples:

https://play.battlesnake.io/g/9e1bf12b-5679-4a2e-9d43-29cabe03d62e/
https://play.battlesnake.io/g/b0ec999e-6d86-419b-939d-d2750101fa3c/
https://play.battlesnake.io/g/ced9550d-0736-410c-a6cb-82195babee28/
